### PR TITLE
Layout/CommentIndentation サポートされていない設定を削除

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -43,11 +43,11 @@ Style/BracesAroundHashParameters:
 # Align `when` with `case`.
 Layout/CaseIndentation:
   Enabled: true
+  EnforcedStyle: case
 
 # Align comments with method definitions.
 Layout/CommentIndentation:
   Enabled: true
-  EnforcedStyle: case
 
 Layout/ElseAlignment:
   Enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -43,7 +43,7 @@ Style/BracesAroundHashParameters:
 # Align `when` with `case`.
 Layout/CaseIndentation:
   Enabled: true
-  EnforcedStyle: case
+  EnforcedStyle: end
 
 # Align comments with method definitions.
 Layout/CommentIndentation:


### PR DESCRIPTION
[Warn] Performance Cops will be removed from RuboCop 0.68. Use rubocop-performance gem instead.
       https://github.com/rubocop-hq/rubocop/tree/master/manual/migrate_performance_cops.md

Warning: Layout/CommentIndentation does not support EnforcedStyle parameter.

Supported parameters are:

  - Enabled
