### PR TITLE
無駄な記述を削除

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,20 +4,22 @@ AllCops:
   # to ignore them, so only the ones explicitly set in this file are enabled.
   DisabledByDefault: true
   Exclude:
-    - '**/templates/**/*'
-    - '**/vendor/**/*'
-    - 'actionmailbox/test/dummy/**/*'
-    - 'actionpack/lib/action_dispatch/journey/parser.rb'
-    - 'actiontext/test/dummy/**/*'
-    - 'bin/**/*'
-    - 'config/puma.rb'
-    - 'db/schema.rb'
+    - 'db/**/*'
+    - 'config/**/*'
+    - 'script/**/*'
     - 'node_modules/**/*'
-    - 'railties/test/fixtures/tmp/**/*'
+    - 'test/**/*'
+    - 'spec/**/*'
+    - 'client/**/*'
+    - 'bin/**/*'
+    - 'vendor/**/*'
+    - '**/Gemfile'
+    - '**/Gemfile.lock'
+    - !ruby/regexp /old_and_unused\.rb$/
 
 Performance:
   Exclude:
-    - '**/test/**/*'
+    - '**/spec/**/*'
 
 Rails:
   Enabled: true
@@ -25,12 +27,12 @@ Rails:
 # Prefer assert_not over assert !
 Rails/AssertNot:
   Include:
-    - '**/test/**/*'
+    - '**/spec/**/*'
 
 # Prefer assert_not_x over refute_x
 Rails/RefuteMethods:
   Include:
-    - '**/test/**/*'
+    - '**/spec/**/*'
 
 # Prefer &&/|| over and/or.
 Style/AndOr:


### PR DESCRIPTION
`.rubocop.yml` を作成した時に、railsで使用しているファイルをそのまま使用してしまったので、明らかに不要な記述が含まれていたため、削除しました。