### PR TITLE
remove performance config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,10 +17,6 @@ AllCops:
     - '**/Gemfile.lock'
     - !ruby/regexp /old_and_unused\.rb$/
 
-Performance:
-  Exclude:
-    - '**/spec/**/*'
-
 Rails:
   Enabled: true
 
@@ -217,25 +213,4 @@ Style/ColonMethodCall:
   Enabled: true
 
 Style/TrivialAccessors:
-  Enabled: true
-
-Performance/FlatMap:
-  Enabled: true
-
-Performance/RedundantMerge:
-  Enabled: true
-
-Performance/StartWith:
-  Enabled: true
-
-Performance/EndWith:
-  Enabled: true
-
-Performance/RegexpMatch:
-  Enabled: true
-
-Performance/ReverseEach:
-  Enabled: true
-
-Performance/UnfreezeString:
   Enabled: true


### PR DESCRIPTION
```
Warning: unrecognized cop Performance found in .rubocop-https---raw-githubusercontent-com-zinbun-dev-zinbun-dev-rubocop-master--rubocop-yml
Warning: unrecognized cop Performance/FlatMap found in .rubocop-https---raw-githubusercontent-com-zinbun-dev-zinbun-dev-rubocop-master--rubocop-yml
Warning: unrecognized cop Performance/RedundantMerge found in .rubocop-https---raw-githubusercontent-com-zinbun-dev-zinbun-dev-rubocop-master--rubocop-yml
Warning: unrecognized cop Performance/StartWith found in .rubocop-https---raw-githubusercontent-com-zinbun-dev-zinbun-dev-rubocop-master--rubocop-yml
Warning: unrecognized cop Performance/EndWith found in .rubocop-https---raw-githubusercontent-com-zinbun-dev-zinbun-dev-rubocop-master--rubocop-yml
Warning: unrecognized cop Performance/RegexpMatch found in .rubocop-https---raw-githubusercontent-com-zinbun-dev-zinbun-dev-rubocop-master--rubocop-yml
Warning: unrecognized cop Performance/ReverseEach found in .rubocop-https---raw-githubusercontent-com-zinbun-dev-zinbun-dev-rubocop-master--rubocop-yml
Warning: unrecognized cop Performance/UnfreezeString found in .rubocop-https---raw-githubusercontent-com-zinbun-dev-zinbun-dev-rubocop-master--rubocop-yml
Warning: unrecognized cop Performance found in .rubocop.yml
Warning: unrecognized cop Performance/FlatMap found in .rubocop.yml
Warning: unrecognized cop Performance/RedundantMerge found in .rubocop.yml
Warning: unrecognized cop Performance/StartWith found in .rubocop.yml
Warning: unrecognized cop Performance/EndWith found in .rubocop.yml
Warning: unrecognized cop Performance/RegexpMatch found in .rubocop.yml
Warning: unrecognized cop Performance/ReverseEach found in .rubocop.yml
Warning: unrecognized cop Performance/UnfreezeString found in .rubocop.yml
```

上記の解消

ref: http://koic.hatenablog.com/entry/extract-performance-cops-from-rubocop-core