### PR TITLE
remove cop braces around hash parameters.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -35,12 +35,6 @@ Style/AndOr:
   EnforcedStyle: conditionals
   Enabled: true
 
-# Do not use braces for hash literals when they are the last argument of a
-# method call.
-Style/BracesAroundHashParameters:
-  Enabled: true
-  EnforcedStyle: context_dependent
-
 # Align `when` with `case`.
 Layout/CaseIndentation:
   Enabled: true


### PR DESCRIPTION
Style/BracesAroundHashParametersを削除。
↓理由
https://github.com/rails/rails/commit/0770c025bde2b2748c8620bae56d71f49f667f72